### PR TITLE
ARM Template Updates to Include Function Apps for HMRC and Datamart

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -30,12 +30,29 @@
         },
         "containerArray": {
             "type": "array"
+        },
+        "workerAspSize": {
+            "type": "string",
+            "defaultValue": "1"
+        },
+        "workerAspInstances": {
+            "type": "int",
+            "defaultValue": 1
+        },
+        "loggingRedisConnectionString": {
+            "type": "securestring"
+        },
+        "configurationStorageConnectionString": {
+            "type": "string"
         }
     },
     "variables": {
         "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
         "resourceNamePrefix": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
         "storageAccountName": "[toLower(concat('das', parameters('resourceEnvironmentName'), parameters('serviceName'), 'str'))]",
+        "workerAppServicePlanName": "[concat(variables('resourceNamePrefix'), 'wkr-asp')]",
+        "workerFunctionAppStorageAccountName": "[concat('das', parameters('resourceEnvironmentName'), parameters('serviceName'),'wkrstr')]",
+        "workerFunctionAppName": "[concat(variables('resourceNamePrefix'),'wkr-fa')]",
         "databaseSuffixArray": [
             "-staging-db"
         ]
@@ -125,12 +142,135 @@
                     }
                 }
             }
+        },
+        {
+            "apiVersion": "2017-05-10",
+            "name": "worker-function-app-storage-account",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'storage-account-arm.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "storageAccountName": {
+                        "value": "[variables('workerFunctionAppStorageAccountName')]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2017-05-10",
+            "name": "worker-app-service-plan",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'app-service-plan.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "appServicePlanName": {
+                        "value": "[variables('workerAppServicePlanName')]"
+                    },
+                    "aspSize": {
+                        "value": "[parameters('workerAspSize')]"
+                    },
+                    "aspInstances": {
+                        "value": "[parameters('workerAspInstances')]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2017-05-10",
+            "name": "worker-function-app-insights",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'application-insights.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "appInsightsName": {
+                        "value": "[variables('workerFunctionAppName')]"
+                    },
+                    "attachedService": {
+                        "value": "[variables('workerFunctionAppName')]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2017-05-10",
+            "name": "worker-function-app",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'function-app.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "functionAppName": {
+                        "value": "[variables('workerFunctionAppName')]"
+                    },
+                    "appServicePlanName": {
+                        "value": "[variables('workerAppServicePlanName')]"
+                    },
+                    "appServicePlanResourceGroup": {
+                        "value": "[resourceGroup().name]"
+                    },
+                    "functionAppAppSettings": {
+                        "value": [
+                            {
+                                "name": "AzureWebJobsStorage",
+                                "value": "[reference('worker-function-app-storage-account').outputs.storageConnectionString.value]"
+                            },
+                            {
+                                "name": "AzureWebJobsDashboard",
+                                "value": "[reference('worker-function-app-storage-account').outputs.storageConnectionString.value]"
+                            },
+                            {
+                                "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+                                "value": "[reference('worker-function-app-insights').outputs.InstrumentationKey.value]"
+                            },
+                            {
+                                "name": "FUNCTIONS_EXTENSION_VERSION",
+                                "value": "~2"
+                            },
+                            {
+                                "name": "EnvironmentName",
+                                "value": "[toUpper(parameters('resourceEnvironmentName'))]"
+                            },
+                            {
+                                "name": "LoggingRedisConnectionString",
+                                "value": "[parameters('loggingRedisConnectionString')]"
+                            },
+                            {
+                                "name": "ConfigurationStorageConnectionString",
+                                "value": "[parameters('configurationStorageConnectionString')]"
+                            }
+                        ]
+                    }
+                }
+            },
+            "dependsOn": [
+                "worker-app-service-plan",
+                "worker-function-app-storage-account"                
+            ]
         }
     ],
     "outputs": {
         "StagingDatabaseName": {
             "type": "string",
             "value": "[concat(variables('resourceNamePrefix'), variables('databaseSuffixArray')[0])]"
+        },
+        "WorkerFunctionAppName": {
+            "type": "string",
+            "value": "[variables('workerFunctionAppName')]"
         }
     }
 }

--- a/azure/template.json
+++ b/azure/template.json
@@ -351,8 +351,7 @@
         "WorkerHmrcFunctionAppName": {
             "type": "string",
             "value": "[variables('workerHmrcFunctionAppName')]"
-        }
-        ,
+        },
         "WorkerDatamartFunctionAppName": {
             "type": "string",
             "value": "[variables('workerDatamartFunctionAppName')]"

--- a/azure/template.json
+++ b/azure/template.json
@@ -2,10 +2,10 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "resourceEnvironmentName" :{
+        "resourceEnvironmentName": {
             "type": "string"
         },
-        "serviceName" :{
+        "serviceName": {
             "type": "string"
         },
         "sqlServerResourceGroupName": {
@@ -43,7 +43,7 @@
             "type": "securestring"
         },
         "configurationStorageConnectionString": {
-            "type": "string"
+            "type": "securestring"
         }
     },
     "variables": {
@@ -52,7 +52,8 @@
         "storageAccountName": "[toLower(concat('das', parameters('resourceEnvironmentName'), parameters('serviceName'), 'str'))]",
         "workerAppServicePlanName": "[concat(variables('resourceNamePrefix'), 'wkr-asp')]",
         "workerFunctionAppStorageAccountName": "[concat('das', parameters('resourceEnvironmentName'), parameters('serviceName'),'wkrstr')]",
-        "workerFunctionAppName": "[concat(variables('resourceNamePrefix'),'wkr-fa')]",
+        "workerHmrcFunctionAppName": "[concat(variables('resourceNamePrefix'),'hmrcwkr-fa')]",
+        "workerDatamartFunctionAppName": "[concat(variables('resourceNamePrefix'),'datamartwkr-fa')]",
         "databaseSuffixArray": [
             "-staging-db"
         ]
@@ -91,20 +92,20 @@
                         "value": "[variables('storageAccountName')]"
                     },
                     "containerName": {
-                      "value": "[parameters('containerArray')[copyIndex()].name]"
+                        "value": "[parameters('containerArray')[copyIndex()].name]"
                     },
                     "publicAccess": {
-                      "value": "[parameters('containerArray')[copyIndex()].publicAccess]"
+                        "value": "[parameters('containerArray')[copyIndex()].publicAccess]"
                     }
                 }
             },
             "copy": {
-              "name": "containercopy",
-              "count": "[length(parameters('containerArray'))]"
-          },
-          "dependsOn": [
-            "storage-account"
-          ]
+                "name": "containercopy",
+                "count": "[length(parameters('containerArray'))]"
+            },
+            "dependsOn": [
+                "storage-account"
+            ]
         },
         {
             "apiVersion": "2017-05-10",
@@ -185,7 +186,7 @@
         },
         {
             "apiVersion": "2017-05-10",
-            "name": "worker-function-app-insights",
+            "name": "worker-hmrc-function-app-insights",
             "type": "Microsoft.Resources/deployments",
             "properties": {
                 "mode": "Incremental",
@@ -195,17 +196,37 @@
                 },
                 "parameters": {
                     "appInsightsName": {
-                        "value": "[variables('workerFunctionAppName')]"
+                        "value": "[variables('workerHmrcFunctionAppName')]"
                     },
                     "attachedService": {
-                        "value": "[variables('workerFunctionAppName')]"
+                        "value": "[variables('workerHmrcFunctionAppName')]"
                     }
                 }
             }
         },
         {
             "apiVersion": "2017-05-10",
-            "name": "worker-function-app",
+            "name": "worker-datamart-function-app-insights",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'application-insights.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "appInsightsName": {
+                        "value": "[variables('workerDatamartFunctionAppName')]"
+                    },
+                    "attachedService": {
+                        "value": "[variables('workerDatamartFunctionAppName')]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2017-05-10",
+            "name": "worker-hmrc-function-app",
             "type": "Microsoft.Resources/deployments",
             "properties": {
                 "mode": "Incremental",
@@ -215,7 +236,7 @@
                 },
                 "parameters": {
                     "functionAppName": {
-                        "value": "[variables('workerFunctionAppName')]"
+                        "value": "[variables('workerHmrcFunctionAppName')]"
                     },
                     "appServicePlanName": {
                         "value": "[variables('workerAppServicePlanName')]"
@@ -235,7 +256,7 @@
                             },
                             {
                                 "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
-                                "value": "[reference('worker-function-app-insights').outputs.InstrumentationKey.value]"
+                                "value": "[reference('worker-hmrc-function-app-insights').outputs.InstrumentationKey.value]"
                             },
                             {
                                 "name": "FUNCTIONS_EXTENSION_VERSION",
@@ -259,7 +280,66 @@
             },
             "dependsOn": [
                 "worker-app-service-plan",
-                "worker-function-app-storage-account"                
+                "worker-function-app-storage-account"
+            ]
+        },
+        {
+            "apiVersion": "2017-05-10",
+            "name": "worker-datamart-function-app",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'function-app.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "functionAppName": {
+                        "value": "[variables('workerDatamartFunctionAppName')]"
+                    },
+                    "appServicePlanName": {
+                        "value": "[variables('workerAppServicePlanName')]"
+                    },
+                    "appServicePlanResourceGroup": {
+                        "value": "[resourceGroup().name]"
+                    },
+                    "functionAppAppSettings": {
+                        "value": [
+                            {
+                                "name": "AzureWebJobsStorage",
+                                "value": "[reference('worker-function-app-storage-account').outputs.storageConnectionString.value]"
+                            },
+                            {
+                                "name": "AzureWebJobsDashboard",
+                                "value": "[reference('worker-function-app-storage-account').outputs.storageConnectionString.value]"
+                            },
+                            {
+                                "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+                                "value": "[reference('worker-datamart-function-app-insights').outputs.InstrumentationKey.value]"
+                            },
+                            {
+                                "name": "FUNCTIONS_EXTENSION_VERSION",
+                                "value": "~2"
+                            },
+                            {
+                                "name": "EnvironmentName",
+                                "value": "[toUpper(parameters('resourceEnvironmentName'))]"
+                            },
+                            {
+                                "name": "LoggingRedisConnectionString",
+                                "value": "[parameters('loggingRedisConnectionString')]"
+                            },
+                            {
+                                "name": "ConfigurationStorageConnectionString",
+                                "value": "[parameters('configurationStorageConnectionString')]"
+                            }
+                        ]
+                    }
+                }
+            },
+            "dependsOn": [
+                "worker-app-service-plan",
+                "worker-function-app-storage-account"
             ]
         }
     ],
@@ -268,9 +348,14 @@
             "type": "string",
             "value": "[concat(variables('resourceNamePrefix'), variables('databaseSuffixArray')[0])]"
         },
-        "WorkerFunctionAppName": {
+        "WorkerHmrcFunctionAppName": {
             "type": "string",
-            "value": "[variables('workerFunctionAppName')]"
+            "value": "[variables('workerHmrcFunctionAppName')]"
+        }
+        ,
+        "WorkerDatamartFunctionAppName": {
+            "type": "string",
+            "value": "[variables('workerDatamartFunctionAppName')]"
         }
     }
 }

--- a/azure/template.json
+++ b/azure/template.json
@@ -51,7 +51,6 @@
         "resourceNamePrefix": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
         "storageAccountName": "[toLower(concat('das', parameters('resourceEnvironmentName'), parameters('serviceName'), 'str'))]",
         "workerAppServicePlanName": "[concat(variables('resourceNamePrefix'), 'wkr-asp')]",
-        "workerFunctionAppStorageAccountName": "[concat('das', parameters('resourceEnvironmentName'), parameters('serviceName'),'wkrstr')]",
         "workerHmrcFunctionAppName": "[concat(variables('resourceNamePrefix'),'hmrcwkr-fa')]",
         "workerDatamartFunctionAppName": "[concat(variables('resourceNamePrefix'),'datamartwkr-fa')]",
         "databaseSuffixArray": [
@@ -146,23 +145,6 @@
         },
         {
             "apiVersion": "2017-05-10",
-            "name": "worker-function-app-storage-account",
-            "type": "Microsoft.Resources/deployments",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(variables('deploymentUrlBase'),'storage-account-arm.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "storageAccountName": {
-                        "value": "[variables('workerFunctionAppStorageAccountName')]"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "2017-05-10",
             "name": "worker-app-service-plan",
             "type": "Microsoft.Resources/deployments",
             "properties": {
@@ -248,11 +230,11 @@
                         "value": [
                             {
                                 "name": "AzureWebJobsStorage",
-                                "value": "[reference('worker-function-app-storage-account').outputs.storageConnectionString.value]"
+                                "value": "[reference('storage-account').outputs.storageConnectionString.value]"
                             },
                             {
                                 "name": "AzureWebJobsDashboard",
-                                "value": "[reference('worker-function-app-storage-account').outputs.storageConnectionString.value]"
+                                "value": "[reference('storage-account').outputs.storageConnectionString.value]"
                             },
                             {
                                 "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
@@ -280,7 +262,7 @@
             },
             "dependsOn": [
                 "worker-app-service-plan",
-                "worker-function-app-storage-account"
+                "storage-account"
             ]
         },
         {
@@ -307,11 +289,11 @@
                         "value": [
                             {
                                 "name": "AzureWebJobsStorage",
-                                "value": "[reference('worker-function-app-storage-account').outputs.storageConnectionString.value]"
+                                "value": "[reference('storage-account').outputs.storageConnectionString.value]"
                             },
                             {
                                 "name": "AzureWebJobsDashboard",
-                                "value": "[reference('worker-function-app-storage-account').outputs.storageConnectionString.value]"
+                                "value": "[reference('storage-account').outputs.storageConnectionString.value]"
                             },
                             {
                                 "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
@@ -339,7 +321,7 @@
             },
             "dependsOn": [
                 "worker-app-service-plan",
-                "worker-function-app-storage-account"
+                "storage-account"
             ]
         }
     ],


### PR DESCRIPTION
As requested by Hima and Rob, a separate function app has been added to the ARM template. The new resources to be deployed include:

- 2x App Insights for the two Function Apps. 
- 1x Storage Account for Function App logs.
- 1x App Service Plan for the two Function apps.
- 2x Function Apps for HMRC and Datamart. 

Parameters, variables and outputs updated as required.