### PR TITLE
Hot fix to accomdate long keywords

### DIFF
--- a/src/SFA.DAS.DATA.MANAGEMENT/StoredProcedure/ImportVacanciesAdditionalInfoToPL.sql
+++ b/src/SFA.DAS.DATA.MANAGEMENT/StoredProcedure/ImportVacanciesAdditionalInfoToPL.sql
@@ -118,7 +118,7 @@ SELECT vc.CandidateId                                                  as Candid
 	  ,dbo.Fn_ConvertTimeStampToDateTime(fSS.DateCreatedTimeStamp)      as DateCreatedTimeStamp
 	  ,dbo.Fn_ConvertTimeStampToDateTime(fss.DateUpdatedTimeStamp)      as DateUpdatedTimeStamp
 	  ,fss.[Location]
-	  ,fss.Keywords
+	  ,LEFT(fss.Keywords,256) as Keywords
 	  ,fss.WithInDistance
 	  ,fss.ApprenticeshipLevel
 	  ,Fss.BinaryId                                                     as SourceApprenticeshipId

--- a/src/SFA.DAS.DATA.MANAGEMENT/Tables/Stg_FAA_SavedSearches.sql
+++ b/src/SFA.DAS.DATA.MANAGEMENT/Tables/Stg_FAA_SavedSearches.sql
@@ -9,7 +9,7 @@
  ,DateUpdatedTimeStamp varchar(256)
  ,CandidateId varchar(256)
  ,[Location] varchar(256)
- ,Keywords varchar(256)
+ ,Keywords varchar(1096)
  ,WithinDistance varchar(256) 
  ,ApprenticeshipLevel varchar(256) 
  ,RunId bigint  default(-1)


### PR DESCRIPTION
Currently the import vacancies in prod is failing due to keyword entered in FAA searches being longer than 256 characters, the longest char length in prod is 548 hence we decided to increase the staging column length to be twice the size - 1096 characters.
However such long characters are not expected to be actual keywords hence it will be truncated to 256 characters before its loaded to presetation layer.